### PR TITLE
Use card for shop model

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,10 +3,21 @@
 @import "font-awesome";
 
 /* main */
+body {
+  background-color: #f9f9ff;
+}
 
 h2 {
   font-weight: bold;
 }
+
+.card {
+  background-color: white;
+  margin-bottom: 15px;
+  width: 21rem;
+}
+
+
 
 .restaurant-info-table-title {
   margin: 15px 0;
@@ -92,6 +103,33 @@ th {
   border-radius: 50%;
   object-fit: cover;
 }
+
+/* icon */
+.fa-red {
+  color: red;
+}
+
+.fa-blue {
+  color: blue;
+}
+
+.fa-darkgrey {
+  color: darkgrey;
+}
+
+/* messages */
+.error {
+  color: red;
+}
+
+#error_explanation {
+  color: red;
+}
+
+.alert {
+  color: red;
+}
+
 
 /* footer */
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -16,7 +16,7 @@ class ShopsController < ApplicationController
     if @shop.save
       redirect_to root_url
     else
-      flash[:errors] = ["あなたは店舗を登録する権利がありません。"]
+      flash.now[:errors] = ["店舗登録ができませんでした。"]
       render 'shops/new'
     end
   end

--- a/app/views/goods/_good.html.slim
+++ b/app/views/goods/_good.html.slim
@@ -1,5 +1,5 @@
 = form_with model: comment, url: shop_comment_goods_path(shop_id: comment.shop_id, comment_id: comment.id), method: :post do |f|
   = hidden_field_tag :comment_id, comment.id
   = button_tag type: 'submit' do
-    i.far.fa-thumbs-up
+    i.far.fa-thumbs-up.fa-blue
   = comment.user_goods.count

--- a/app/views/goods/_normal.html.slim
+++ b/app/views/goods/_normal.html.slim
@@ -1,5 +1,5 @@
 = form_with model: comment, url: shop_comment_good_path(shop_id: comment.shop_id, comment_id: comment.id), method: :delete do |f|
   = hidden_field_tag :comment_id, comment.id
   = button_tag type: 'submit' do
-    i.fas.fa-thumbs-up
+    i.fas.fa-thumbs-up.fa-blue
   = comment.user_goods.count

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,9 +11,10 @@ html
    = render 'layouts/header'
    .container.text-center
       p.notice = notice.presence
-      p.alert = alert.presence
-      - if flash[:errors].present?
-        - flash[:errors].each do |messages|
-          = messages
+      #error_explanation
+        p.alert = alert.presence
+        - if flash[:errors].present?
+          - flash[:errors].each do |messages|
+            = messages
       = yield
       = render 'layouts/footer'

--- a/app/views/likes/_like.html.slim
+++ b/app/views/likes/_like.html.slim
@@ -2,5 +2,5 @@
 = form_with model: @shop, url: likes_path, method: :post do |f|
   = hidden_field_tag :shop_id, @shop.id
   = button_tag type: 'submit' do
-    i.far.fa-heart
+    i.far.fa-heart.fa-red
   = @shop.liked_users.count

--- a/app/views/likes/_unlike.html.slim
+++ b/app/views/likes/_unlike.html.slim
@@ -2,5 +2,5 @@
 = form_with model: @shop, url: like_path(@shop), html: { method: :delete} do |f|
   = hidden_field_tag :shop_id, @shop.id
   = button_tag type: 'submit' do
-    i.fa.fa-heart
+    i.fa.fa-heart.fa-red
   = @shop.liked_users.count

--- a/app/views/shops/_shop.html.slim
+++ b/app/views/shops/_shop.html.slim
@@ -1,17 +1,1 @@
-.col-sm
-  = link_to shop.name, shop
-  .content
-    = image_tag shop.picture.url if shop.picture?
-    br
-    | 住所：
-    = shop.address
-    - if shop.budget_lunch.present?
-      br
-      | ランチの予算：
-      | 〜 #{shop.budget_lunch}円
-    br
-    | ディナーの予算：
-    | 〜 #{shop.budget_dinner}円
-    br
-    | 営業時間：
-    = shop.opening_hours
+= render "shops/shop_display", shop: shop

--- a/app/views/shops/_shop_display.html.slim
+++ b/app/views/shops/_shop_display.html.slim
@@ -1,0 +1,26 @@
+.col-sm
+  .card
+    .card-title
+      = link_to shop.name, shop
+    .card-img-top
+      - if shop.picture?
+        = link_to shop
+          = image_tag shop.picture.url
+    .card-body
+      | 住所：
+      = shop.address
+      - if shop.budget_lunch.present?
+        br
+        | ランチの予算：
+        | 〜 #{shop.budget_lunch}円
+      br
+      | ディナーの予算：
+      | 〜 #{shop.budget_dinner}円
+      br
+      | 営業時間：
+      = shop.opening_hours
+    .card-footer
+      | お気に入り
+      i.fa.fa-heart.fa-red.mr-2 = shop.liked_users.count
+      | コメント
+      i.fas.fa-comment.fa-darkgrey = shop.comments.count

--- a/app/views/users/likes.html.slim
+++ b/app/views/users/likes.html.slim
@@ -1,19 +1,4 @@
 .container
   .row.align-items-center
     - @shops.each do |shop|
-      .col-sm
-        = link_to shop.name, shop
-        .content
-        = image_tag shop.picture.url if shop.picture?
-        br
-        | 住所：
-        = shop.address
-        br
-        | ランチの予算：
-        | 〜 #{shop.budget_lunch}円
-        br
-        | ディナーの予算：
-        | 〜 #{shop.budget_lunch}円
-        br
-        | 営業時間：
-        = shop.opening_hours
+      = render "shops/shop_display", shop: shop


### PR DESCRIPTION
bootstrapのカードをshopに適用して、サイトのデザインを見やすくしました。
お気に入り数とコメント数をカードの中で表示させる仕様にしました。
また、ユーザーのお気に入りとホームページで使用していたコードが重複していたので、パーシャルをつかって共通化しました。
