### PR TITLE
Remove geocoder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'devise-i18n-views'
 gem 'carrierwave', '~> 2.0'
 gem 'fog-aws'
 gem 'font-awesome-sass', '~> 5.9.0'
-gem 'geocoder'
 gem 'gmaps4rails'
 gem 'ransack'
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,7 +1,6 @@
 class ShopsController < ApplicationController
   before_action :authenticate_user!
   before_action :admin_user, only: [:new, :edit, :create, :update, :destroy]
-  before_action :set_coordinates, only: [:create, :update]
 
   def new
     @shop = current_user.shops.build
@@ -13,15 +12,8 @@ class ShopsController < ApplicationController
 
   def create
     @shop = current_user.shops.build(shop_params)
-    if @geo_result.present?
-      @shop.latitude = @geo_result.first.coordinates[0]
-      @shop.longitude = @geo_result.first.coordinates[1]
-      if @shop.save
-        redirect_to root_url
-      else
-        flash.now[:errors] = ["店舗登録ができませんでした。"]
-        render 'shops/new'
-      end
+    if @shop.save
+      redirect_to root_url
     else
       flash.now[:errors] = ["店舗登録ができませんでした。"]
       render 'shops/new'
@@ -30,16 +22,9 @@ class ShopsController < ApplicationController
 
   def update
     @shop = current_user.shops.find(params[:id])
-    if @geo_result.present?
-      @shop.latitude = @geo_result.first.coordinates[0]
-      @shop.longitude = @geo_result.first.coordinates[1]
-      if @shop.update_attributes(shop_params)
-        flash[:notice] = "情報を更新しました。"
-        redirect_to root_url
-      else
-        flash.now[:errors] = ["店舗更新ができませんでした。"]
-        render 'edit'
-      end
+    if @shop.update_attributes(shop_params)
+      flash[:notice] = "情報を更新しました。"
+      redirect_to root_url
     else
       flash.now[:errors] = ["店舗更新ができませんでした。"]
       render 'edit'
@@ -66,15 +51,11 @@ class ShopsController < ApplicationController
   private
 
    def shop_params
-     params.require(:shop).permit(:name, :address, :phone_number, :budget_lunch, :budget_dinner, :opening_hours, :day_off, :picture)
+     params.require(:shop).permit(:name, :address, :latitude, :longitude, :phone_number, :budget_lunch, :budget_dinner, :opening_hours, :day_off, :picture)
    end
 
    def admin_user
      redirect_to root_url unless current_user.admin?
-   end
-
-   def set_coordinates
-     @geo_result = Geocoder.search(params[:shop][:address]).presence
    end
 
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -4,8 +4,6 @@ class Shop < ApplicationRecord
 
   mount_uploader :picture, PictureUploader
 
-  geocoded_by :address
-
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
   has_many :comments, dependent: :destroy
@@ -13,8 +11,9 @@ class Shop < ApplicationRecord
   validates :user_id, presence: true
   validates :name, presence: true
   validates :address, presence: true
+  validates :latitude, presence: true
+  validates :longitude, presence: true
   validate :picture_size
-  after_validation :geocode, if: :address_changed?
 
   private
 

--- a/app/views/shops/edit.html.slim
+++ b/app/views/shops/edit.html.slim
@@ -7,26 +7,34 @@ h2
     = f.text_field :name, autofocus: true
   .field
     = f.label :address, "住所"
-    |&nbsp; 例: 東京都〇〇区〇〇
+    |&nbsp; 例: 東京都中央区銀座1-3-10
     br
     = f.text_field :address
+  .field
+    = f.label :latitude, "緯度"
+    br
+    = f.text_field :latitude
+  .field
+    = f.label :longitude, "経度"
+    br
+    = f.text_field :longitude
   .field
     = f.label :phone_number, "電話番号"
     br
     = f.text_field :phone_number
   .field
     = f.label :budget_lunch, "ランチの予算"
-    |&nbsp; 例: 1000円~2000円
+    |&nbsp; 例: 2000
     br
     = f.text_field :budget_lunch
   .field
     = f.label :budget_dinner, "ディナーの予算"
-    |&nbsp; 例: 5000円~10000円
+    |&nbsp; 例: 10000
     br
     = f.text_field :budget_dinner
   .field
     = f.label :opening_hours, "営業時間"
-    |&nbsp; 例: 午前12時~午後9時
+    |&nbsp; 例: 11:00~23:00
     br
     = f.text_field :opening_hours
   .field

--- a/app/views/shops/new.html.slim
+++ b/app/views/shops/new.html.slim
@@ -7,13 +7,21 @@ h2
     = f.text_field :name, autofocus: true
   .field
     = f.label :address, "住所"
-    |&nbsp; 例: 東京都〇〇区〇〇
+    |&nbsp; 例: 東京都中央区銀座1-3-10
     br
     = f.text_field :address
   .field
-   = f.label :phone_number, "電話番号"
-   br
-   = f.text_field :phone_number
+    = f.label :latitude, "緯度"
+    br
+    = f.text_field :latitude
+  .field
+    = f.label :longitude, "経度"
+    br
+    = f.text_field :longitude
+  .field
+    = f.label :phone_number, "電話番号"
+    br
+    = f.text_field :phone_number
   .field
     = f.label :budget_lunch, "ランチの予算"
     |&nbsp; 例: 2000
@@ -34,7 +42,8 @@ h2
     br
     = f.text_field :day_off
   .picture
-    f.label :picture
+    = f.label :picture, "写真"
+    br
     = f.file_field :picture, accept: 'image/jpeg, image/gif, image/png'
     br
     br

--- a/db/migrate/20191008105255_add_null_constraint_of_latitude_to_shops.rb
+++ b/db/migrate/20191008105255_add_null_constraint_of_latitude_to_shops.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintOfLatitudeToShops < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :shops, :latitude, false
+  end
+end

--- a/db/migrate/20191008105358_add_null_constraint_of_longitude_to_shops.rb
+++ b/db/migrate/20191008105358_add_null_constraint_of_longitude_to_shops.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintOfLongitudeToShops < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :shops, :longitude, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_04_143207) do
+ActiveRecord::Schema.define(version: 2019_10_08_105358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 2019_10_04_143207) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "latitude"
-    t.float "longitude"
+    t.float "latitude", null: false
+    t.float "longitude", null: false
     t.integer "budget_dinner"
     t.string "day_off"
     t.string "phone_number"


### PR DESCRIPTION
住所を入れても緯度と経度を取得できないことが多かったため、Gemのgeocoderを削除しました。
店舗登録時と更新時に人力で緯度と経度を入力する仕様になりました。
また、緯度と経度を必須事項にしました。